### PR TITLE
Fix for objectids and introducing limits

### DIFF
--- a/sdks/java/io/mongodb/build.gradle
+++ b/sdks/java/io/mongodb/build.gradle
@@ -27,7 +27,7 @@ dependencies {
   shadow library.java.slf4j_api
   shadow library.java.findbugs_jsr305
   shadow library.java.joda_time
-  shadow "org.mongodb:mongo-java-driver:3.2.2"
+  shadow "org.mongodb:mongo-java-driver:3.2.2-textiq"
   testCompile project(path: ":runners:direct-java", configuration: "shadow")
   testCompile library.java.junit
   testCompile library.java.slf4j_jdk14


### PR DESCRIPTION
* Allowing for string and integers as types for `_id` instead of assuming all ids are `ObjectId`s.
* New parameter allows to limit the number of records produced by the mongodbio reader. This allows for batching. Notice this is only an approximation; how many records are produced depends on the distribution of the data over the different readers.

