### PR TITLE
Added toStrings for spark dashboard

### DIFF
--- a/runners/core-java/build.gradle
+++ b/runners/core-java/build.gradle
@@ -31,6 +31,7 @@ test {
 
 dependencies {
   compile library.java.guava
+  compileOnly library.java.commons_lang3
   compileOnly library.java.findbugs_annotations
   shadow project(path: ":model:pipeline", configuration: "shadow")
   shadow project(path: ":sdks:java:core", configuration: "shadow")

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/DistributionData.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/DistributionData.java
@@ -59,4 +59,10 @@ public abstract class DistributionData implements Serializable {
   public DistributionResult extractResult() {
     return DistributionResult.create(sum(), count(), min(), max());
   }
+
+  public String toString() {
+    return "[" + min() + ", "
+           + String.format("%.2f", (count() > 0 ? ((double) sum()) / ((double) count()) : 0.0))
+           + ", " + max() + "]";
+  }
 }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerImpl.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerImpl.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Map.Entry;
 import javax.annotation.Nullable;
 import org.apache.beam.runners.core.construction.metrics.MetricKey;
 import org.apache.beam.runners.core.metrics.MetricUpdates.MetricUpdate;
@@ -210,5 +211,25 @@ public class MetricsContainerImpl implements Serializable, MetricsContainer {
     for (Map.Entry<MetricName, GaugeCell> counter : updates.entries()) {
       current.get(counter.getKey()).update(counter.getValue().getCumulative());
     }
+  }
+
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{");
+    for (Entry<MetricName, CounterCell> e: counters.entries()) {
+      sb.append(" " + e.getKey().namespace() + ":" + e.getKey().name()
+                + " :: " + e.getValue().getCumulative());
+    }
+    for (Entry<MetricName, DistributionCell> e: distributions.entries()) {
+      sb.append(" " + e.getKey().namespace() + ":" + e.getKey().name()
+                + " :: " + e.getValue().getCumulative());
+    }
+    for (Entry<MetricName, GaugeCell> e: gauges.entries()) {
+      sb.append(" " + e.getKey().namespace() + ":" + e.getKey().name()
+                + " :: " + e.getValue().getCumulative());
+    }
+
+    sb.append(" }");
+    return sb.toString();
   }
 }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMap.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMap.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.runners.core.construction.metrics.MetricFiltering;
 import org.apache.beam.runners.core.construction.metrics.MetricKey;
@@ -36,6 +37,7 @@ import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.metrics.MetricResult;
 import org.apache.beam.sdk.metrics.MetricResults;
 import org.apache.beam.sdk.metrics.MetricsFilter;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Metrics containers by step.
@@ -452,5 +454,17 @@ public class MetricsContainerStepMap implements Serializable {
         return committed;
       }
     }
+
+  }
+
+  public static final String EMPTY = "";
+  private static final int STRING_BUILDER_SIZE = 256;
+
+  public String toString() {
+    return "[<br/> " + StringUtils.join(metricsContainers
+                                .entrySet()
+                                .stream()
+                                .map(e -> e.getKey() + " : " + e.getValue().toString())
+                                .collect(Collectors.toSet()), ", ") + "</br>]";
   }
 }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMap.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMap.java
@@ -457,9 +457,6 @@ public class MetricsContainerStepMap implements Serializable {
 
   }
 
-  public static final String EMPTY = "";
-  private static final int STRING_BUILDER_SIZE = 256;
-
   public String toString() {
     return "[<br/> " + StringUtils.join(metricsContainers
                                 .entrySet()

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMap.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerStepMap.java
@@ -458,10 +458,10 @@ public class MetricsContainerStepMap implements Serializable {
   }
 
   public String toString() {
-    return "[<br/> " + StringUtils.join(metricsContainers
+    return "[ " + StringUtils.join(metricsContainers
                                 .entrySet()
                                 .stream()
                                 .map(e -> e.getKey() + " : " + e.getValue().toString())
-                                .collect(Collectors.toSet()), ", ") + "</br>]";
+                                .collect(Collectors.toSet()), ", ") + " ]";
   }
 }


### PR DESCRIPTION
The spark dashboard on port 4040 includes beam metrics. Unfortunately, the `toString()` methods of relevant classes is not defined, so it's not possible to actually see the metrics that are being collected, as it simply prints the class name and a hash.

Added the required `toString` methods to show the data. Formatting can be improved, but at least it's there to see now.
