### PR TITLE
[QUIN-537] Fix for single split

### DIFF
--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
@@ -380,6 +380,7 @@ public class MongoDbIO {
         }
 
         int numSplits = splitKeys.size();
+
         List<String> shardFilters = splitKeysToFilters(splitKeys, spec.filter(), spec.idType());
 
         int limitPerReader = -1;
@@ -463,6 +464,12 @@ public class MongoDbIO {
           rangeFilter = String.format("{ $and: [ {\"_id\":{$lte:%s}}",
               getFilterString(idType, splitKey));
           filters.add(formatFilter(rangeFilter, additionalFilter));
+          // If there is only one, also generate a range from the split to the end
+          if (splitKeys.size() == 1) {
+            rangeFilter = String.format("{ $and: [ {\"_id\":{$gt:%s}}",
+                                        getFilterString(idType, splitKey));
+            filters.add(formatFilter(rangeFilter, additionalFilter));
+          }
         } else if (i == splitKeys.size() - 1) {
           // this is the last split in the list, the filters define
           // the range from the previous split to the current split and also

--- a/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDbIOTest.java
+++ b/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDbIOTest.java
@@ -148,11 +148,18 @@ public class MongoDbIOTest implements Serializable {
 
   @Test
   public void testSplitIntoFilters() throws Exception {
+    // A single split will result in two filters
     ArrayList<Document> documents = new ArrayList<>();
     documents.add(new Document("_id", 56));
+    List<String> filters = MongoDbIO.BoundedMongoDbSource.splitKeysToFilters(documents, null);
+    assertEquals(2, filters.size());
+    assertEquals("{ $and: [ {\"_id\":{$lte:ObjectId(\"56\")}} ]}", filters.get(0));
+    assertEquals("{ $and: [ {\"_id\":{$gt:ObjectId(\"56\")}} ]}", filters.get(1));
+
+    // Add two more splits; now we should have 4 filters
     documents.add(new Document("_id", 109));
     documents.add(new Document("_id", 256));
-    List<String> filters = MongoDbIO.BoundedMongoDbSource.splitKeysToFilters(documents, null);
+    filters = MongoDbIO.BoundedMongoDbSource.splitKeysToFilters(documents, null);
     assertEquals(4, filters.size());
     assertEquals("{ $and: [ {\"_id\":{$lte:ObjectId(\"56\")}} ]}", filters.get(0));
     assertEquals("{ $and: [ {\"_id\":{$gt:ObjectId(\"56\"),$lte:ObjectId(\"109\")}} ]}",


### PR DESCRIPTION
I discovered a bug in beam (https://issues.apache.org/jira/browse/BEAM-7081), where incorrect ranges are computed if there is only a single split. This fix corrects that behaviour. A new jar has been pushed to the central repo.